### PR TITLE
Add threaded Python log monitor for cross-seed apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # cross-seed-script
-Cross seed auto management for long running jobs
+
+Utilities for managing cross-seed applications on TrueNAS.  The Python
+`monitor.py` script watches log files for HTTP 429 errors and
+automatically restarts affected applications.
+
+## Usage
+
+```bash
+python monitor.py
+```
+
+The script scans each application's log every 10 seconds.  When a 429
+error is detected a background thread will:
+
+1. Stop the application via `midclt`.
+2. Confirm the app is stopped.
+3. Clear the `job_log` table in `cross-seed.db`.
+4. Remove the `logs/` directory for a fresh start.
+5. Wait 30 minutes before restarting the application.
+```

--- a/app_manager.py
+++ b/app_manager.py
@@ -1,0 +1,89 @@
+import json
+import logging
+import shutil
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+
+from config import BASE_DIR, RESTART_DELAY
+
+logger = logging.getLogger(__name__)
+
+
+def _run_midclt(args):
+    """Run a midclt command and return completed process."""
+    return subprocess.run(
+        ["midclt", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def stop_app(app: str) -> None:
+    """Scale an application to 0 replicas."""
+    logger.info("Stopping %s", app)
+    _run_midclt(["call", "-job", "chart.release.scale", app, '{"replica_count": 0}'])
+
+
+def start_app(app: str) -> None:
+    """Scale an application to 1 replica."""
+    logger.info("Starting %s", app)
+    _run_midclt(["call", "-job", "chart.release.scale", app, '{"replica_count": 1}'])
+
+
+def _get_app_scale(app: str) -> int:
+    """Return the current replica count for an application."""
+    proc = _run_midclt(["call", "chart.release.get_instance", app])
+    data = json.loads(proc.stdout)
+    return data.get("status", {}).get("scale", -1)
+
+
+def wait_for_stop(app: str, timeout: int = 60) -> bool:
+    """Wait until an application reports scale 0."""
+    end = time.time() + timeout
+    while time.time() < end:
+        if _get_app_scale(app) == 0:
+            return True
+        time.sleep(2)
+    return False
+
+
+def clear_job_log(app: str) -> None:
+    """Delete all rows from job_log table for an application."""
+    db_path = BASE_DIR / app / "cross-seed.db"
+    if not db_path.exists():
+        logger.warning("Database not found for %s: %s", app, db_path)
+        return
+    logger.info("Clearing job_log for %s", app)
+    conn = sqlite3.connect(db_path)
+    try:
+        with conn:
+            conn.execute("DELETE FROM job_log")
+    finally:
+        conn.close()
+
+
+def clear_logs(app: str) -> None:
+    """Remove logs directory for an application."""
+    log_dir = BASE_DIR / app / "logs"
+    if not log_dir.exists():
+        logger.warning("Logs directory not found for %s: %s", app, log_dir)
+        return
+    logger.info("Removing logs in %s", log_dir)
+    shutil.rmtree(log_dir)
+
+
+def restart_procedure(app: str) -> None:
+    """Full restart procedure for an application."""
+    stop_app(app)
+    if not wait_for_stop(app):
+        logger.error("Failed to confirm %s has stopped", app)
+        return
+    clear_job_log(app)
+    clear_logs(app)
+    logger.info("Waiting %d seconds before restarting %s", RESTART_DELAY, app)
+    time.sleep(RESTART_DELAY)
+    start_app(app)
+    logger.info("Restarted %s", app)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+# Base directory containing app configurations
+BASE_DIR = Path('/mnt/epool/config')
+
+# Names of the cross-seed applications to monitor
+APPS = [
+    'cross-seed-ab',
+    'cross-seed-ant',
+    'cross-seed-ath',
+    'cross-seed-bhd',
+    'cross-seed-blu',
+    'cross-seed-cg',
+    'cross-seed-hdb',
+    'cross-seed-kg',
+]
+
+# Interval (in seconds) between log scans
+SCAN_INTERVAL = 10
+
+# Delay (in seconds) before restarting an application after a failure
+RESTART_DELAY = 30 * 60  # 30 minutes

--- a/monitor.py
+++ b/monitor.py
@@ -1,0 +1,64 @@
+import logging
+import threading
+import time
+import re
+from pathlib import Path
+
+from config import BASE_DIR, APPS, SCAN_INTERVAL
+from app_manager import restart_procedure
+
+logger = logging.getLogger(__name__)
+
+# Active restart threads keyed by app name
+_active_threads: dict[str, threading.Thread] = {}
+_lock = threading.Lock()
+
+# Regular expression to match isolated "429" codes
+ERROR_RE = re.compile(r'(^|[^0-9])429([^0-9]|$)')
+
+
+def check_logs() -> None:
+    """Scan log files for each application and trigger restarts if needed."""
+    for app in APPS:
+        with _lock:
+            if app in _active_threads:
+                continue
+        log_file = BASE_DIR / app / "logs" / "info.current.log"
+        if not log_file.exists():
+            logger.warning("Log file not found for %s: %s", app, log_file)
+            continue
+        try:
+            with log_file.open() as fh:
+                for line in fh:
+                    if ERROR_RE.search(line):
+                        logger.warning("429 error detected for %s", app)
+                        t = threading.Thread(target=_worker, args=(app,), daemon=True)
+                        with _lock:
+                            _active_threads[app] = t
+                        t.start()
+                        break
+        except Exception:
+            logger.exception("Failed reading log for %s", app)
+
+
+def _worker(app: str) -> None:
+    try:
+        restart_procedure(app)
+    finally:
+        with _lock:
+            _active_threads.pop(app, None)
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    logger.info("Starting log monitor")
+    while True:
+        check_logs()
+        time.sleep(SCAN_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `config.py` with base directory, app list, and scan timing
- Implement `app_manager.py` to stop/start apps, clear logs and job data, and restart after delay
- Create `monitor.py` that scans logs for 429 errors and spawns restart threads
- Update README with usage instructions for new Python monitor

## Testing
- `python -m py_compile config.py app_manager.py monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b75fd78a1c832ca2d8ca37338f0fe7