### PR TITLE
Add logging to debug app scale lookup

### DIFF
--- a/app_manager.py
+++ b/app_manager.py
@@ -48,6 +48,9 @@ def _get_app_scale(app: str) -> int:
     scale.
     """
     proc = _run_midclt(["call", "chart.release.get_instance", app])
+    logger.debug(
+        "midclt get_instance output for %s: %s", app, proc.stdout.strip()
+    )
     try:
         data = json.loads(proc.stdout)
     except json.JSONDecodeError:
@@ -63,7 +66,9 @@ def wait_for_stop(app: str, timeout: int = 60) -> bool:
     """Wait until an application reports scale 0."""
     end = time.time() + timeout
     while time.time() < end:
-        if _get_app_scale(app) == 0:
+        scale = _get_app_scale(app)
+        logger.debug("Current scale for %s: %s", app, scale)
+        if scale == 0:
             return True
         time.sleep(2)
     return False


### PR DESCRIPTION
## Summary
- log raw `midclt` response when retrieving app scale
- log scale values while waiting for an app to stop

## Testing
- `python -m py_compile app_manager.py monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7664ce87c832c93bfb13223e02026