### PR TITLE
Add timestamped file logging for monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+monitor_logs/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ automatically restarts affected applications.
 python monitor.py
 ```
 
+Logs from each run are written to the console and also saved under
+`monitor_logs/` with a timestamped filename (e.g.
+`monitor_logs/monitor_20240101_120000.log`).
+
 The script scans each application's log every 10 seconds.  When a 429
 error is detected a background thread will:
 
@@ -18,4 +22,3 @@ error is detected a background thread will:
 3. Clear the `job_log` table in `cross-seed.db`.
 4. Remove the `logs/` directory for a fresh start.
 5. Wait 30 minutes before restarting the application.
-```

--- a/monitor.py
+++ b/monitor.py
@@ -2,6 +2,7 @@ import logging
 import threading
 import time
 import re
+from datetime import datetime
 from pathlib import Path
 
 from config import BASE_DIR, APPS, SCAN_INTERVAL
@@ -52,9 +53,19 @@ def _worker(app: str) -> None:
 
 
 def main() -> None:
+    """Entry point for the log monitoring daemon."""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_dir = Path("monitor_logs")
+    log_dir.mkdir(exist_ok=True)
+    log_file = log_dir / f"monitor_{timestamp}.log"
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",
+        handlers=[
+            logging.StreamHandler(),
+            logging.FileHandler(log_file, encoding="utf-8"),
+        ],
     )
     logger.info("Starting log monitor")
     while True:


### PR DESCRIPTION
## Summary
- log monitor runs to both console and timestamped files
- document location of log files

## Testing
- `python -m py_compile monitor.py app_manager.py config.py`
- `python monitor.py & sleep 2; kill %1`


------
https://chatgpt.com/codex/tasks/task_e_68b76a030e64832c9c87b6771dbf369a